### PR TITLE
Feat/#46 user context 생성

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
-  <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
+  <!-- <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script> -->
+  <!-- FIX: 배포 시 .min.js로 변경할 예정입니다. -->
+  <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
   <body>
     <div id="root"></div>
     <div id="modal"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { Global, ThemeProvider } from "@emotion/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RecoilRoot } from "recoil";
-import Router from "router/Router";
+import { UserProvider } from "contexts/UserContext";
 import { globalStyle, theme } from "styles";
+import Router from "router/Router";
 import "./styles/fonts.css";
 
 import dayjs from "dayjs";
@@ -25,9 +26,11 @@ function App() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
           <Global styles={globalStyle} />
-          <Router />
-          <Modal />
-          {/* Fix : 레이아웃 수정 예정 */}
+          <UserProvider>
+            <Router />
+            <Modal />
+            {/* Fix: 레이아웃 수정 예정 */}
+          </UserProvider>
         </ThemeProvider>
       </QueryClientProvider>
     </RecoilRoot>

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 
 const instance: AxiosInstance = axios.create({
@@ -9,7 +8,7 @@ const instance: AxiosInstance = axios.create({
 
 instance.interceptors.request.use(
   (config) => {
-    const accessToken = Cookies.get("token");
+    const accessToken = Cookies.get("accessToken");
     if (accessToken) {
       config.headers = config.headers || {};
       config.headers["Authorization"] = `Bearer ${accessToken}`;
@@ -26,15 +25,8 @@ instance.interceptors.response.use(
   (response: AxiosResponse) => {
     return response;
   },
-  async (error) => {
-    const navigate = useNavigate();
-    if (error.response) {
-      if (error.response.status === 404) {
-        navigate("/404");
-      } else if (error.response.status === 401) {
-        navigate("/landing");
-      }
-    }
+  (error) => {
+    console.error("API Error: ", error);
     return Promise.reject(error);
   }
 );

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,101 @@
+import React, { createContext, useState, useCallback, useEffect } from "react";
+import { KAKAO_CLIENT_ID, KAKAO_REDIRECT_URL, CLIENT_SECRET } from "config";
+import { ax } from "apis/axios";
+import Cookies from "js-cookie";
+import qs from "qs";
+
+interface TokenResponse {
+  access_token: string;
+}
+
+interface UserProfile {
+  email: string;
+  nickname: string;
+}
+
+export interface UserContextType {
+  isLoggedIn: boolean;
+  userProfile: UserProfile;
+  getToken: (code: string) => Promise<void>;
+  logout: () => void;
+}
+
+export const UserContext = createContext<UserContextType | undefined>(
+  undefined
+);
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [userProfile, setUserProfile] = useState<UserProfile>({
+    email: "",
+    nickname: "",
+  });
+
+  const getToken = useCallback(async (code: string) => {
+    console.log("getToken called with code:", code);
+    const payload = qs.stringify({
+      grant_type: "authorization_code",
+      client_id: KAKAO_CLIENT_ID,
+      redirect_uri: KAKAO_REDIRECT_URL,
+      code: code,
+      client_secret: CLIENT_SECRET,
+    });
+
+    try {
+      const res = await ax.post<TokenResponse>(
+        "https://kauth.kakao.com/oauth/token",
+        payload
+      );
+      Cookies.set("accessToken", res.data.access_token, {
+        expires: 1,
+        secure: true,
+        sameSite: "strict",
+      });
+      setIsLoggedIn(true);
+
+      // Kakao SDK 초기화 확인 및 API 요청
+      if (!window.Kakao.isInitialized()) {
+        window.Kakao.init(KAKAO_CLIENT_ID);
+      }
+      if (window.Kakao.isInitialized() && window.Kakao.API) {
+        const profileData = await window.Kakao.API.request({
+          url: "/v2/user/me",
+        });
+        console.log("Profile Data:", profileData);
+        setUserProfile({
+          email: profileData.kakao_account.email,
+          nickname: profileData.properties.nickname,
+        });
+      } else {
+        console.error("Kakao SDK is not initialized or API is unavailable");
+      }
+    } catch (err) {
+      console.log("Error fetching user data:", err);
+      Cookies.remove("accessToken");
+      setIsLoggedIn(false);
+      setUserProfile({ email: "", nickname: "" });
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    Cookies.remove("accessToken");
+    setIsLoggedIn(false);
+    setUserProfile({ email: "", nickname: "" });
+  }, []);
+
+  useEffect(() => {
+    const checkLoginStatus = () => {
+      const accessToken = Cookies.get("accessToken");
+      setIsLoggedIn(!!accessToken);
+    };
+    checkLoginStatus();
+  }, []);
+
+  return (
+    <UserContext.Provider value={{ isLoggedIn, userProfile, getToken, logout }}>
+      {children}
+    </UserContext.Provider>
+  );
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useModal } from "./useModal";
+export { default as useUser } from "./useUser";

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { UserContext, UserContextType } from "contexts/UserContext";
+
+const useUser = (): UserContextType => {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error("useUser must be used within a UserProvider");
+  }
+  return context;
+};
+
+export default useUser;

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,58 +1,24 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { CLIENT_SECRET, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URL } from "config";
-import { ax } from "apis/axios";
-import Cookies from "js-cookie";
-import qs from "qs";
-
-interface TokenResponse {
-  access_token: string;
-}
+import { useUser } from "hooks";
 
 export default function Auth() {
   const navigate = useNavigate();
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const { isLoggedIn, getToken } = useUser();
   const params = new URL(document.URL).searchParams;
   const code = params.get("code");
 
-  const getToken = useCallback(async () => {
-    const payload = qs.stringify({
-      grant_type: "authorization_code",
-      client_id: KAKAO_CLIENT_ID,
-      redirect_uri: KAKAO_REDIRECT_URL,
-      code: code,
-      client_secret: CLIENT_SECRET,
-    });
-
-    try {
-      const res = await ax.post<TokenResponse>(
-        "https://kauth.kakao.com/oauth/token",
-        payload
-      );
-      window.Kakao.init(KAKAO_CLIENT_ID);
-      window.Kakao.Auth.setAccessToken(res.data.access_token);
-
-      // 쿠키에 토큰 저장: HttpOnly, Secure 옵션은 서버에서 설정
-      Cookies.set("accessToken", res.data.access_token, {
-        expires: 1,
-        secure: true,
-        sameSite: "strict",
-      });
-      setIsLoggedIn(true);
-      navigate("/profile"); // 프로필페이지는 논의 예정입니다.
-    } catch (err) {
-      console.log(err);
-      Cookies.remove("accessToken");
-      setIsLoggedIn(false);
-      navigate("/");
+  useEffect(() => {
+    if (!isLoggedIn && code) {
+      getToken(code);
     }
-  }, [navigate, setIsLoggedIn, code]);
+  }, [code, getToken, isLoggedIn]);
 
   useEffect(() => {
-    const accessToken = Cookies.get("accessToken");
-    setIsLoggedIn(!!accessToken);
-    getToken();
-  }, [getToken, setIsLoggedIn]);
+    if (isLoggedIn) {
+      navigate("/profile");
+    }
+  }, [isLoggedIn, navigate]);
 
   return (
     <div>

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -1,58 +1,26 @@
 import * as S from "./Profile.styled";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import Cookies from "js-cookie";
-
-interface KakaoUserProfile {
-  kakao_account: {
-    email: string;
-  };
-  properties: {
-    nickname: string;
-  };
-}
+import { useUser } from "hooks";
 
 export default function Profile() {
   const navigate = useNavigate();
-
-  const [email, setEmail] = useState<string>("");
-  const [nickName, setNickName] = useState<string>("");
+  const { isLoggedIn, userProfile, logout } = useUser();
 
   useEffect(() => {
-    const accessToken = Cookies.get("accessToken");
-    if (!accessToken) {
-      navigate("/"); // 토큰이 없으면 랜딩페이지로 redirect
+    if (!isLoggedIn) {
+      navigate("/");
       return;
     }
-
-    const getProfile = async () => {
-      if (window.Kakao && window.Kakao.API) {
-        try {
-          const data: KakaoUserProfile = await window.Kakao.API.request({
-            url: "/v2/user/me",
-          });
-          setEmail(data.kakao_account.email);
-          setNickName(data.properties.nickname);
-        } catch (err) {
-          console.log(err);
-          navigate("/");
-        }
-      } else {
-        console.log("Kakao API is not initialized.");
-        navigate("/");
-      }
-    };
-
-    getProfile();
-  }, [navigate]);
+  }, [navigate, isLoggedIn, logout]);
 
   return (
     <S.ContentsBox>
       <S.Logo_Basic />
       <S.Text_h1>enjoy your Lucky Day!</S.Text_h1>
       <S.Text_h2>
-        {nickName}님, 반갑습니다. <br />
-        📧 {email}
+        {userProfile.nickname}님, 반갑습니다. <br />
+        📧 {userProfile.email}
       </S.Text_h2>
       <button onClick={() => navigate("/luckyBoard")}>럭키보드로 가기</button>
     </S.ContentsBox>


### PR DESCRIPTION
## ISSUE 번호

#46 

<br/>

## 🔎 작업 내용

- 전역 관리를 위한 `UserContext` 생성
- `useUser` hook 생성
- `App.tsx`에 `UserProvider` 추가
- `axios.ts`에서 hook 제거
- Kakao SDK 로드 스크립트 임시 교체

<br/>

## 참고 사항

- 전역 사용자 상태 관리를 위해 `UserProvider`를 추가하였습니다.
- `axios.ts`에 hook이 없는 것이 나을 것 같아서 에러 로깅만 처리하고, 에러를 다시 throw 하여 컴포넌트에서 처리할 수 있도록 수정하였습니다.
- SDK 스크립트는 배포 시 `min.js`로 교체할 예정입니다. 
