### PR TITLE
Fix/#79 배포 이슈 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,3 @@
 {
-  "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }],
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "routes": [{ "src": "/[^.]+", "dest": "/" }]
 }


### PR DESCRIPTION
## ISSUE 번호

- #79

<br/>

## 🔎 작업 내용

- 배포 이슈 수정
  - vercel.json 파일에 `rewrites`, `redirects`, `headers`, `cleanUrls`, `trailingSlash` 를 사용하고 있다면, `routes`를 사용할 수 없습니다.

<br/>

## 참고 사항

- 공유되어야하는 사항이 있다면 여기에 작성해주세요
