### PR TITLE
Feat/#104 이미지 리사이징 기능 추가 및 회고 페이지 수정

### DIFF
--- a/src/components/domain/reviewLuckyDay/fileUploader/FileUploader.tsx
+++ b/src/components/domain/reviewLuckyDay/fileUploader/FileUploader.tsx
@@ -28,7 +28,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelect }) => {
   return (
     <S.Container>
       <S.UploadBox onClick={handleClick}>
-        {loading ? <ComponentSpinner /> : null}
+        {loading && <ComponentSpinner />}
         <S.HiddenFileInput
           type="file"
           ref={fileInputRef}

--- a/src/components/domain/reviewLuckyDay/fileUploader/FileUploader.tsx
+++ b/src/components/domain/reviewLuckyDay/fileUploader/FileUploader.tsx
@@ -1,7 +1,6 @@
-// components/FileUploader.tsx
-
-import React, { useRef } from "react";
 import * as S from "./FileUploader.styled";
+import React, { useRef, useState } from "react";
+import { ComponentSpinner } from "components";
 
 interface FileUploaderProps {
   onFileSelect: (file: File) => void;
@@ -9,11 +8,14 @@ interface FileUploaderProps {
 
 const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelect }) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
+      setLoading(true);
       onFileSelect(file);
+      setLoading(false);
     }
   };
 
@@ -26,6 +28,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelect }) => {
   return (
     <S.Container>
       <S.UploadBox onClick={handleClick}>
+        {loading ? <ComponentSpinner /> : null}
         <S.HiddenFileInput
           type="file"
           ref={fileInputRef}

--- a/src/pages/reviewLuckyDay/ReviewLuckyDayPage.styled.ts
+++ b/src/pages/reviewLuckyDay/ReviewLuckyDayPage.styled.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { css, Theme } from "@emotion/react";
+import { css } from "@emotion/react";
 
 export const Container = styled.div`
   display: flex;
@@ -35,25 +35,22 @@ export const TextBox = styled.div`
   `}
 `;
 
-export const ReviewInput = (theme: Theme) => css`
+export const ReviewTextarea = styled.textarea`
   width: 270px;
-  height: 120px;
-  padding: 10px 20px;
-  margin-top: 70px;
+  height: 100px;
+  padding: 20px;
+  margin-top: 80px;
   margin-bottom: 70px;
   border: 0;
   background-color: transparent;
   text-align: center;
-  color: ${theme.colors.black};
-  ${theme.fonts.headline2}
-
+  color: ${({ theme }) => theme.colors.black};
+  ${({ theme }) => theme.fonts.headline2};
+  resize: none;
+  overflow-y: auto;
+  white-space: pre-wrap;
   &:focus {
     outline: none;
-  }
-
-  &:disabled {
-    background-color: ${theme.colors.gray};
-    color: ${theme.colors.gray};
   }
 `;
 

--- a/src/pages/reviewLuckyDay/ReviewLuckyDayPage.tsx
+++ b/src/pages/reviewLuckyDay/ReviewLuckyDayPage.tsx
@@ -1,6 +1,6 @@
 import * as S from "./ReviewLuckyDayPage.styled";
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useToast } from "hooks";
 import { useGetLuckyDayDetail } from "services";
 import {
@@ -16,6 +16,7 @@ import axios from "axios";
 
 export default function ReviewLuckyDayPage() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const { data, isLoading, error } = useGetLuckyDayDetail(id || "");
 
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
@@ -62,6 +63,7 @@ export default function ReviewLuckyDayPage() {
 
       if (response.status === 200) {
         addToast({ content: "저장되었습니다." });
+        navigate(`/luckydays/${id}`);
       } else {
         addToast({ content: "저장에 실패했습니다." });
       }

--- a/src/pages/reviewLuckyDay/ReviewLuckyDayPage.tsx
+++ b/src/pages/reviewLuckyDay/ReviewLuckyDayPage.tsx
@@ -49,12 +49,9 @@ export default function ReviewLuckyDayPage() {
       new Blob([JSON.stringify(reviewReqDto)], { type: "application/json" })
     );
 
-    formData.append(
-      "image",
-      uploadedFile
-        ? uploadedFile
-        : new Blob([JSON.stringify(null)], { type: "application/json" })
-    );
+    if (uploadedFile) {
+      formData.append("image", uploadedFile);
+    }
 
     try {
       const response = await ax.post("/luckydays/review", formData, {
@@ -71,11 +68,15 @@ export default function ReviewLuckyDayPage() {
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
         console.error("Error response:", error.response);
-        addToast({
-          content: `저장 중 오류가 발생했습니다: ${
-            error.response.data.message || error.response.status
-          }`,
-        });
+        if (error.response.status === 2013) {
+          addToast({ content: "이미지 또는 내용을 입력해 주세요." });
+        } else {
+          addToast({
+            content: `저장 중 오류가 발생했습니다: ${
+              error.response.data.message || error.response.status
+            }`,
+          });
+        }
       } else {
         console.error("Error:", error);
         addToast({ content: "저장 중 오류가 발생했습니다" });

--- a/src/pages/reviewLuckyDay/ReviewLuckyDayPage.tsx
+++ b/src/pages/reviewLuckyDay/ReviewLuckyDayPage.tsx
@@ -3,7 +3,12 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useToast } from "hooks";
 import { useGetLuckyDayDetail } from "services";
-import { FileUploader, PageSpinner, SvgButton } from "components";
+import {
+  FileUploader,
+  PageSpinner,
+  SingleButtonLayout,
+  SvgButton,
+} from "components";
 import { ShortBoxIcon } from "assets";
 import { formatDate } from "utils";
 import { ax } from "apis/axios";
@@ -44,9 +49,12 @@ export default function ReviewLuckyDayPage() {
       new Blob([JSON.stringify(reviewReqDto)], { type: "application/json" })
     );
 
-    if (uploadedFile) {
-      formData.append("image", uploadedFile);
-    }
+    formData.append(
+      "image",
+      uploadedFile
+        ? uploadedFile
+        : new Blob([JSON.stringify(null)], { type: "application/json" })
+    );
 
     try {
       const response = await ax.post("/luckydays/review", formData, {
@@ -88,41 +96,43 @@ export default function ReviewLuckyDayPage() {
   const { dday, actNm } = data.resData;
 
   return (
-    <S.Container>
-      <S.TextBox>{formatDate(dday, "YYYY-MM-DD")}</S.TextBox>
-      <S.ReviewBox>
-        <S.TextBox>{actNm}</S.TextBox>
-        <S.ImageUploadBox>
-          <FileUploader onFileSelect={handleFileSelect} />
-          {uploadedFile && (
-            <S.ImageBox>
-              <img
-                src={URL.createObjectURL(uploadedFile)}
-                alt="Uploaded preview"
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  borderRadius: "10px",
-                }}
-              />
-            </S.ImageBox>
-          )}
-        </S.ImageUploadBox>
-        <S.ReviewTextarea
-          value={review}
-          onChange={handleReviewChange}
-          placeholder={"100자 이내로 럭키 데이를 기록해 보세요:)"}
-        />
-      </S.ReviewBox>
-      <S.ButtonBox>
-        <SvgButton
-          label="저장하기"
-          icon={<ShortBoxIcon />}
-          width="120px"
-          height="50px"
-          onClick={handleSubmit}
-        />
-      </S.ButtonBox>
-    </S.Container>
+    <SingleButtonLayout>
+      <S.Container>
+        <S.TextBox>{formatDate(dday, "YYYY-MM-DD")}</S.TextBox>
+        <S.ReviewBox>
+          <S.TextBox>{actNm}</S.TextBox>
+          <S.ImageUploadBox>
+            <FileUploader onFileSelect={handleFileSelect} />
+            {uploadedFile && (
+              <S.ImageBox>
+                <img
+                  src={URL.createObjectURL(uploadedFile)}
+                  alt="Uploaded preview"
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    borderRadius: "10px",
+                  }}
+                />
+              </S.ImageBox>
+            )}
+          </S.ImageUploadBox>
+          <S.ReviewTextarea
+            value={review}
+            onChange={handleReviewChange}
+            placeholder={"100자 이내로 럭키 데이를 기록해 보세요:)"}
+          />
+        </S.ReviewBox>
+        <S.ButtonBox>
+          <SvgButton
+            label="저장하기"
+            icon={<ShortBoxIcon />}
+            width="120px"
+            height="50px"
+            onClick={handleSubmit}
+          />
+        </S.ButtonBox>
+      </S.Container>
+    </SingleButtonLayout>
   );
 }

--- a/src/pages/viewLuckyActivity/ViewLuckyActivityPage.tsx
+++ b/src/pages/viewLuckyActivity/ViewLuckyActivityPage.tsx
@@ -46,7 +46,7 @@ function ViewLuckyActivityPage() {
         </S.LuckydayDetailInfo>
         <S.Button onClick={handleClickRecord}>
           <SvgFrame css={S.svgFrame} icon={<ShortBoxIcon />} />
-          <span>{data?.resData.review ? "기록하기" : "기록보기"}</span>
+          <span>{data?.resData.review ? "기록보기" : "기록하기"}</span>
         </S.Button>
       </S.ViewLuckyActivityPage>
     </SingleButtonLayout>

--- a/src/pages/viewLuckyActivity/ViewLuckyActivityPage.tsx
+++ b/src/pages/viewLuckyActivity/ViewLuckyActivityPage.tsx
@@ -15,9 +15,9 @@ function ViewLuckyActivityPage() {
 
   const handleClickRecord = () => {
     if (data?.resData.review) {
-      navigate("/"); //TODO: 적절한 경로로 변경 : 상세 보기
+      navigate(`/luckydays/review/${id}`);
     } else {
-      navigate("/luckyboard"); //TODO: 적절한 경로로 변경 : 기록 남기기
+      navigate(`/luckydays/create/${id}`);
     }
   };
 

--- a/src/pages/viewLuckyDay/ViewLuckyDayPage.styled.ts
+++ b/src/pages/viewLuckyDay/ViewLuckyDayPage.styled.ts
@@ -9,7 +9,6 @@ export const Container = styled.div`
   text-align: center;
   width: 100%;
   padding: 20px;
-  background-color: purple;
 `;
 
 export const ReviewBox = styled.div`
@@ -24,7 +23,6 @@ export const ReviewBox = styled.div`
   background-repeat: no-repeat;
   background-position: center;
   background-image: url("/images/img-review.webp");
-  background-color: yellow;
 `;
 
 export const TextBox = styled.div`
@@ -38,22 +36,49 @@ export const TextBox = styled.div`
 `;
 
 export const ImageBox = styled.div`
-  width: 200px;
-  height: 140px;
-  margin-bottom: 80px;
-  border-radius: 10px;
-  background-color: pink;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: -30px;
 `;
 
-export const ReviewText = styled.div`
+export const Image = styled.div`
+  width: 200px;
+  height: 140px;
+  margin-top: 5px;
+  margin-bottom: 100px;
+  border-radius: 10px;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const DefaultImage = styled.div`
+  width: 85px;
+  height: 85px;
+  margin-top: 20px;
+  margin-bottom: 140px;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const ReviewTextBox = styled.div`
   ${({ theme }) => css`
+    display: flex;
+    justify-content: center;
     width: 270px;
     height: 120px;
+    margin-top: -50px;
     padding: 10px 20px;
-    border: 0;
-    background-color: skyblue;
-    text-align: center;
     color: ${theme.colors.black};
     ${theme.fonts.headline2}
+    word-break: break-word;
+    white-space: pre-wrap;
   `}
 `;

--- a/src/pages/viewLuckyDay/ViewLuckyDayPage.styled.ts
+++ b/src/pages/viewLuckyDay/ViewLuckyDayPage.styled.ts
@@ -57,8 +57,8 @@ export const Image = styled.div`
 `;
 
 export const DefaultImage = styled.div`
-  width: 85px;
-  height: 85px;
+  width: 90px;
+  height: 90px;
   margin-top: 20px;
   margin-bottom: 140px;
   img {

--- a/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
+++ b/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
@@ -1,11 +1,14 @@
 import * as S from "./ViewLuckyDayPage.styled";
 import { useParams } from "react-router-dom";
 import { useGetLuckyDayReview } from "services";
+import { GetLuckyDayDetail } from "types";
+import { useToast } from "hooks";
 import { PageSpinner, SingleButtonLayout } from "components";
 import { formatDate } from "utils";
 
 export default function ViewLuckyDayPage() {
   const { id } = useParams();
+  const { addToast } = useToast();
   console.log("dtlNo:", id);
 
   const { data, isLoading, error } = useGetLuckyDayReview(id || "");
@@ -17,15 +20,19 @@ export default function ViewLuckyDayPage() {
   if (error || !data) {
     console.log("에러 발생:", error);
     console.log("받은 데이터:", data);
-    return <S.Container>오류가 발생했습니다.</S.Container>;
+    addToast({ content: "오류가 발생했습니다." });
+    return;
   }
 
-  const { dday, actNm, review, imageUrl } = data.resData;
+  const { dday, actNm, review, imageUrl } = data.resData as GetLuckyDayDetail;
   console.log("정상 데이터:", data);
   console.log(imageUrl);
 
-  // FIX : 이미지 주소 수정이 필요합니다.
-  // const ImageUrl = `${import.meta.env.VITE_BASE_URL}${imageUrl}`;
+  const ImageUrl = imageUrl
+    ? `${import.meta.env.VITE_BASE_URL}${imageUrl}`
+    : "";
+
+  const isDefaultImage = imageUrl?.includes("/images/default");
 
   return (
     <SingleButtonLayout>
@@ -34,12 +41,18 @@ export default function ViewLuckyDayPage() {
         <S.ReviewBox>
           <S.ImageBox>
             <S.TextBox>{actNm}</S.TextBox>
-            <S.Image>{imageUrl && <img src={imageUrl} />}</S.Image>
-
-            {/* FIX : 디폴트 이미지를 구분하는 파라미터가 없습니다. 백엔드 문의 예정 */}
-            {/* <S.DefaultImage>{imageUrl && <img src={imageUrl} />}</S.DefaultImage> */}
+            {imageUrl &&
+              (isDefaultImage ? (
+                <S.DefaultImage>
+                  <img src={ImageUrl} alt="Default" />
+                </S.DefaultImage>
+              ) : (
+                <S.Image>
+                  <img src={ImageUrl} alt="Uploaded" />
+                </S.Image>
+              ))}
           </S.ImageBox>
-          <S.ReviewTextBox>{review || "리뷰가 없습니다."}</S.ReviewTextBox>
+          <S.ReviewTextBox>{review}</S.ReviewTextBox>
         </S.ReviewBox>
       </S.Container>
     </SingleButtonLayout>

--- a/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
+++ b/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
@@ -2,6 +2,7 @@ import * as S from "./ViewLuckyDayPage.styled";
 import { useParams } from "react-router-dom";
 import { useGetLuckyDayReview } from "services";
 import { PageSpinner } from "components";
+import { formatDate } from "utils";
 
 export default function ViewLuckyDayPage() {
   const { id } = useParams();
@@ -10,11 +11,7 @@ export default function ViewLuckyDayPage() {
   const { data, isLoading, error } = useGetLuckyDayReview(id || "");
 
   if (isLoading) {
-    return (
-      <S.Container>
-        <PageSpinner />
-      </S.Container>
-    );
+    return <PageSpinner />;
   }
 
   if (error || !data) {
@@ -25,16 +22,23 @@ export default function ViewLuckyDayPage() {
 
   const { dday, actNm, review, imageUrl } = data.resData;
   console.log("정상 데이터:", data);
+  console.log(imageUrl);
+
+  // FIX : 이미지 주소 수정이 필요합니다.
+  // const ImageUrl = `${import.meta.env.VITE_BASE_URL}${imageUrl}`;
 
   return (
     <S.Container>
-      <S.TextBox>{dday}</S.TextBox>
+      <S.TextBox>{formatDate(dday, "YYYY-MM-DD")}</S.TextBox>
       <S.ReviewBox>
-        <S.TextBox>{actNm}</S.TextBox>
         <S.ImageBox>
-          {imageUrl && <img src={imageUrl} alt={actNm} />}
+          <S.TextBox>{actNm}</S.TextBox>
+          <S.Image>{imageUrl && <img src={imageUrl} />}</S.Image>
+
+          {/* FIX : 디폴트 이미지를 구분하는 파라미터가 없습니다. 백엔드 문의 예정 */}
+          {/* <S.DefaultImage>{imageUrl && <img src={imageUrl} />}</S.DefaultImage> */}
         </S.ImageBox>
-        <S.ReviewText>{review || "리뷰가 없습니다."}</S.ReviewText>
+        <S.ReviewTextBox>{review || "리뷰가 없습니다."}</S.ReviewTextBox>
       </S.ReviewBox>
     </S.Container>
   );

--- a/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
+++ b/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
@@ -1,7 +1,7 @@
 import * as S from "./ViewLuckyDayPage.styled";
 import { useParams } from "react-router-dom";
 import { useGetLuckyDayReview } from "services";
-import { PageSpinner } from "components";
+import { PageSpinner, SingleButtonLayout } from "components";
 import { formatDate } from "utils";
 
 export default function ViewLuckyDayPage() {
@@ -28,18 +28,20 @@ export default function ViewLuckyDayPage() {
   // const ImageUrl = `${import.meta.env.VITE_BASE_URL}${imageUrl}`;
 
   return (
-    <S.Container>
-      <S.TextBox>{formatDate(dday, "YYYY-MM-DD")}</S.TextBox>
-      <S.ReviewBox>
-        <S.ImageBox>
-          <S.TextBox>{actNm}</S.TextBox>
-          <S.Image>{imageUrl && <img src={imageUrl} />}</S.Image>
+    <SingleButtonLayout>
+      <S.Container>
+        <S.TextBox>{formatDate(dday, "YYYY-MM-DD")}</S.TextBox>
+        <S.ReviewBox>
+          <S.ImageBox>
+            <S.TextBox>{actNm}</S.TextBox>
+            <S.Image>{imageUrl && <img src={imageUrl} />}</S.Image>
 
-          {/* FIX : 디폴트 이미지를 구분하는 파라미터가 없습니다. 백엔드 문의 예정 */}
-          {/* <S.DefaultImage>{imageUrl && <img src={imageUrl} />}</S.DefaultImage> */}
-        </S.ImageBox>
-        <S.ReviewTextBox>{review || "리뷰가 없습니다."}</S.ReviewTextBox>
-      </S.ReviewBox>
-    </S.Container>
+            {/* FIX : 디폴트 이미지를 구분하는 파라미터가 없습니다. 백엔드 문의 예정 */}
+            {/* <S.DefaultImage>{imageUrl && <img src={imageUrl} />}</S.DefaultImage> */}
+          </S.ImageBox>
+          <S.ReviewTextBox>{review || "리뷰가 없습니다."}</S.ReviewTextBox>
+        </S.ReviewBox>
+      </S.Container>
+    </SingleButtonLayout>
   );
 }

--- a/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
+++ b/src/pages/viewLuckyDay/ViewLuckyDayPage.tsx
@@ -1,9 +1,10 @@
 import * as S from "./ViewLuckyDayPage.styled";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
+import { useToast } from "hooks";
 import { useGetLuckyDayReview } from "services";
 import { GetLuckyDayDetail } from "types";
-import { useToast } from "hooks";
-import { PageSpinner, SingleButtonLayout } from "components";
+import { ComponentSpinner, PageSpinner, SingleButtonLayout } from "components";
 import { formatDate } from "utils";
 
 export default function ViewLuckyDayPage() {
@@ -12,6 +13,7 @@ export default function ViewLuckyDayPage() {
   console.log("dtlNo:", id);
 
   const { data, isLoading, error } = useGetLuckyDayReview(id || "");
+  const [imageLoading, setImageLoading] = useState<boolean>(true);
 
   if (isLoading) {
     return <PageSpinner />;
@@ -34,6 +36,10 @@ export default function ViewLuckyDayPage() {
 
   const isDefaultImage = imageUrl?.includes("/images/default");
 
+  const handleImageLoad = () => {
+    setImageLoading(false);
+  };
+
   return (
     <SingleButtonLayout>
       <S.Container>
@@ -41,14 +47,16 @@ export default function ViewLuckyDayPage() {
         <S.ReviewBox>
           <S.ImageBox>
             <S.TextBox>{actNm}</S.TextBox>
+            {imageLoading && <ComponentSpinner />}
+
             {imageUrl &&
               (isDefaultImage ? (
                 <S.DefaultImage>
-                  <img src={ImageUrl} alt="Default" />
+                  <img src={ImageUrl} alt="Default" onLoad={handleImageLoad} />
                 </S.DefaultImage>
               ) : (
                 <S.Image>
-                  <img src={ImageUrl} alt="Uploaded" />
+                  <img src={ImageUrl} alt="Uploaded" onLoad={handleImageLoad} />
                 </S.Image>
               ))}
           </S.ImageBox>

--- a/src/services/luckyday.ts
+++ b/src/services/luckyday.ts
@@ -14,7 +14,6 @@ import {
 import {
   CreateLuckyDayForm,
   GetLuckyDayCycleDetailResponse,
-  GetLuckyDayCycleLastLuckyDaysQueryModel,
   GetLuckyDayCycleList,
   GetLuckyDayCycleQueryModel,
   GetLuckyDayCycleLastLuckyDaysQueryModel,

--- a/src/types/domain/luckyday.ts
+++ b/src/types/domain/luckyday.ts
@@ -25,7 +25,7 @@ export interface CreateLuckyDayQueryModel {
   body: CreateLuckyDayForm;
 }
 
-interface GetLuckyDayDetail {
+export interface GetLuckyDayDetail {
   dtlNo: number;
   actNm: string;
   actInfo: string;


### PR DESCRIPTION
## ISSUE 번호

#104 

<br/>

## 🔎 작업 내용

- 럭키데이 기록하기 페이지 api 로직 수정
- 럭키데이 기록보기 페이지 api 로직 수정
- 럭키데이 활동 navigate 추가
- toast 추가

> 추가된 사항

- 이미지 미선택 시 이미지 필드 제거 로직 수정
- default image 조건부 렌더링 로직 추가
- 리뷰 저장 후 기록 보기 페이지로 이동 로직 추가
- 파일업로더 로딩 처리

<br/>

## 참고 사항

- 리사이징은 아직 작업 중인데 오늘 테스트 하려면 UI가 보여야 할 것 같아서 올립니다. 
- 현재 기록하기에서는 이미지를 넣지 않았을 때 500에러가 터지는 이슈가 있습니다. -> 해결하였습니다.
- 기록보기에서는 이미지 url이 api 정의서와 다른 것 같습니다. -> 문의드리고 수정하였습니다.
- 기록보기에서 사진이 없을 때 default image를 주기로 논의된 것 같은데, 이걸 구분하는 파라미터가 없습니다. -> 경로로 구분해달라는 요청을 받고 해당 부분 수정 완료된 상태입니다.
- 활동 조회 페이지에서 기록하기와 기록보기로 가는 navigate를 설정해두었는데, 기록하기와 기록보기 버튼이 반대로 되어 있는 것 같아서 수정했습니다. 참고 부탁드립니다. 