### PR TITLE
Style/#117 레이아웃 및 럭키보드 반응형 처리

### DIFF
--- a/src/components/common/layout/Layout.styled.ts
+++ b/src/components/common/layout/Layout.styled.ts
@@ -1,15 +1,26 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
+export const LayoutContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100svh;
+    background-color: ${theme.colors.background};
+
+    @media (min-width: 768px) {
+      height: 100vh;
+    }
+  `}
+`;
 
 export const Layout = styled.div`
   max-width: 430px;
   width: 100%;
-  height: 100vh;
-  height: 100svh;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%); // 추후에 상대좌표로 변경할 수 있음
-  background-image: url("/images/background.webp");
+  height: 100%;
   background-size: cover;
   background-position: center;
+  background-image: url("/images/background.webp");
 `;

--- a/src/components/common/layout/Layout.styled.ts
+++ b/src/components/common/layout/Layout.styled.ts
@@ -20,6 +20,10 @@ export const Layout = styled.div`
   max-width: 430px;
   width: 100%;
   height: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%); // FIX : 생성 모달 이슈로 인한 재수정
   background-size: cover;
   background-position: center;
   background-image: url("/images/background.webp");

--- a/src/components/common/layout/Layout.styled.ts
+++ b/src/components/common/layout/Layout.styled.ts
@@ -20,10 +20,6 @@ export const Layout = styled.div`
   max-width: 430px;
   width: 100%;
   height: 100%;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%); // FIX : 생성 모달 이슈로 인한 재수정
   background-size: cover;
   background-position: center;
   background-image: url("/images/background.webp");

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -7,10 +7,12 @@ const Layout = () => {
   const { pathname } = useLocation();
 
   return (
-    <S.Layout>
-      {!(pathname === "/404" || pathname === "/loading") && <Header />}
-      <Outlet />
-    </S.Layout>
+    <S.LayoutContainer>
+      <S.Layout>
+        {!(pathname === "/404" || pathname === "/loading") && <Header />}
+        <Outlet />
+      </S.Layout>
+    </S.LayoutContainer>
   );
 };
 

--- a/src/components/common/layout/navigationToggle/NavigationToggle.styled.ts
+++ b/src/components/common/layout/navigationToggle/NavigationToggle.styled.ts
@@ -13,8 +13,6 @@ export const MenuIcon = styled.div`
 
 export const ToggleBox = styled.div`
   position: absolute;
-  top: 80px;
-  right: 0;
   width: 200px;
   height: 400px;
   border-radius: 15px 0px 0px 15px;

--- a/src/components/common/layout/navigationToggle/NavigationToggle.tsx
+++ b/src/components/common/layout/navigationToggle/NavigationToggle.tsx
@@ -11,6 +11,11 @@ const NavigationToggle: (props: NavigationToggleProps) => JSX.Element = ({
   defaultOn = false,
 }) => {
   const [isToggleVisible, setIsToggleVisible] = useState(defaultOn);
+  const [toggleBoxPosition, setToggleBoxPosition] = useState({
+    top: 0,
+    left: 0,
+    right: "auto" as number | "auto",
+  });
   const toggleRef = useRef<HTMLDivElement>(null);
   const menuIconRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
@@ -43,8 +48,28 @@ const NavigationToggle: (props: NavigationToggleProps) => JSX.Element = ({
   }, []);
 
   const toggleNavigation = () => {
+    if (menuIconRef.current) {
+      const { bottom, right, width } =
+        menuIconRef.current.getBoundingClientRect();
+      const toggleBoxWidth = 200;
+      const screenWidth = window.innerWidth;
+      let leftPosition = right - toggleBoxWidth + width / 2;
+      let rightPosition: number | "auto" = "auto";
+
+      if (leftPosition + toggleBoxWidth > screenWidth) {
+        leftPosition = screenWidth - toggleBoxWidth;
+        rightPosition = 0;
+      }
+
+      setToggleBoxPosition({
+        top: bottom,
+        left: leftPosition,
+        right: rightPosition,
+      });
+    }
     setIsToggleVisible((prevState) => !prevState);
   };
+
   useEffect(() => {
     setIsToggleVisible(false);
   }, [location]);
@@ -55,7 +80,20 @@ const NavigationToggle: (props: NavigationToggleProps) => JSX.Element = ({
         <MenuIcon />
       </S.MenuIcon>
       {isToggleVisible && (
-        <S.ToggleBox ref={toggleRef}>
+        <S.ToggleBox
+          ref={toggleRef}
+          style={{
+            top: `${toggleBoxPosition.top}px`,
+            left:
+              typeof toggleBoxPosition.left === "number"
+                ? `${toggleBoxPosition.left}px`
+                : toggleBoxPosition.left,
+            right:
+              toggleBoxPosition.right === "auto"
+                ? "auto"
+                : `${toggleBoxPosition.right}px`,
+          }}
+        >
           <button onClick={toggleNavigation}></button>
           <S.ToggleContentsBox>
             <S.ProfileBox>

--- a/src/components/common/modal/Modal.styled.ts
+++ b/src/components/common/modal/Modal.styled.ts
@@ -6,4 +6,5 @@ export const Modal = styled.div`
   align-items: center;
   width: 100vw;
   height: 100vh;
+  z-index: 1005;
 `;

--- a/src/components/common/modal/archiveModal/ArchiveModal.styled.ts
+++ b/src/components/common/modal/archiveModal/ArchiveModal.styled.ts
@@ -43,7 +43,7 @@ export const Button = styled.button`
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      color: ${theme.colors.white};
+      color: ${theme.colors.black};
     }
   `}
 `;
@@ -81,6 +81,12 @@ export const LuckyDayButton = styled.button`
 export const svgFrame = (theme: Theme) => css`
   path {
     fill: ${theme.colors.purple};
+  }
+`;
+
+export const svgFrameButton = (theme: Theme) => css`
+  path {
+    fill: ${theme.colors.beige};
   }
 `;
 

--- a/src/components/common/modal/archiveModal/ArchiveModal.tsx
+++ b/src/components/common/modal/archiveModal/ArchiveModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { SvgButton, SvgFrame } from "components";
+import { SvgFrame } from "components";
 import { useModal } from "hooks";
 import { CircleBoxIcon, ShortBoxIcon } from "assets";
 import type { GetLuckyDayCycleDetail } from "types";
@@ -48,13 +48,11 @@ function ArchiveModal({ className, moreInfo, lastInfo }: ArchiveModalProps) {
           )}
         </>
       )}
-      <SvgButton
-        label="닫기"
-        onClick={handleModalClose}
-        icon={<ShortBoxIcon />}
-        width="100px"
-        height="42px"
-      ></SvgButton>
+
+      <S.Button onClick={handleModalClose}>
+        <SvgFrame css={S.svgFrameButton} icon={<ShortBoxIcon />} />
+        <span>닫기</span>
+      </S.Button>
     </S.ArchiveModal>
   );
 }

--- a/src/components/common/svgFrame/centeredSvgFrame/centeredSvgFrame.styled.ts
+++ b/src/components/common/svgFrame/centeredSvgFrame/centeredSvgFrame.styled.ts
@@ -25,7 +25,7 @@ export const Text = styled.div<{ color?: string }>`
     ${(props) => props.theme.fonts.logo}
   }
 
-  @media (max-width: 370px) {
+  @media (max-width: 375px) {
     ${(props) => props.theme.fonts.body1}
   }
 `;

--- a/src/components/common/svgFrame/centeredSvgFrame/centeredSvgFrame.styled.ts
+++ b/src/components/common/svgFrame/centeredSvgFrame/centeredSvgFrame.styled.ts
@@ -20,4 +20,12 @@ export const Text = styled.div<{ color?: string }>`
   top: 50%;
   color: ${(props) => props.color || props.theme.colors.white};
   ${(props) => props.theme.fonts.luckyBall2}
+
+  @media (max-width: 412px) {
+    ${(props) => props.theme.fonts.logo}
+  }
+
+  @media (max-width: 370px) {
+    ${(props) => props.theme.fonts.body1}
+  }
 `;

--- a/src/components/domain/luckyBoard/createLuckyDayButton/CreateLuckyDayButton.styled.ts
+++ b/src/components/domain/luckyBoard/createLuckyDayButton/CreateLuckyDayButton.styled.ts
@@ -7,8 +7,19 @@ export const CreateLuckyDayButton = styled.button`
   background-size: cover;
   background-image: url("/images/empty-white.png");
   cursor: pointer;
+
   & > svg {
     width: 40px;
     height: 40px;
+  }
+
+  @media (max-width: 405px) {
+    width: 50px;
+    height: 50px;
+
+    & > svg {
+      width: 30px;
+      height: 30px;
+    }
   }
 `;

--- a/src/components/domain/luckyBoard/luckyBalls/LuckyBalls.styled.ts
+++ b/src/components/domain/luckyBoard/luckyBalls/LuckyBalls.styled.ts
@@ -6,7 +6,7 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: -40px;
+  margin-top: -55px;
 `;
 
 export const RowBox = styled.div`
@@ -21,6 +21,24 @@ export const LuckyBallFace = styled.div<{ imageUrl: string }>`
   background-repeat: no-repeat;
   background-image: url(${(props) => props.imageUrl});
   cursor: default;
+
+  @media (max-width: 412px) {
+    width: 95px;
+    height: 95px;
+    margin: 8px;
+  }
+
+  @media (max-width: 405px) {
+    width: 90px;
+    height: 90px;
+    margin: 8px;
+  }
+
+  @media (max-width: 370px) {
+    width: 80px;
+    height: 80px;
+    margin: 7px;
+  }
 `;
 
 export const svgFrame = (theme: Theme) => css`
@@ -31,6 +49,24 @@ export const svgFrame = (theme: Theme) => css`
     cursor: pointer;
     pointer-events: auto;
     ${theme.fonts.luckyBall2}
+
+    @media (max-width: 412px) {
+      width: 95px;
+      height: 95px;
+      margin: 8px;
+    }
+
+    @media (max-width: 405px) {
+      width: 90px;
+      height: 90px;
+      margin: 8px;
+    }
+
+    @media (max-width: 370px) {
+      width: 80px;
+      height: 80px;
+      margin: 7px;
+    }
   }
 `;
 

--- a/src/components/domain/luckyBoard/luckyBalls/LuckyBalls.styled.ts
+++ b/src/components/domain/luckyBoard/luckyBalls/LuckyBalls.styled.ts
@@ -34,10 +34,10 @@ export const LuckyBallFace = styled.div<{ imageUrl: string }>`
     margin: 8px;
   }
 
-  @media (max-width: 370px) {
+  @media (max-width: 375px) {
     width: 80px;
     height: 80px;
-    margin: 7px;
+    margin: 6px;
   }
 `;
 
@@ -62,10 +62,10 @@ export const svgFrame = (theme: Theme) => css`
       margin: 8px;
     }
 
-    @media (max-width: 370px) {
+    @media (max-width: 375px) {
       width: 80px;
       height: 80px;
-      margin: 7px;
+      margin: 6px;
     }
   }
 `;

--- a/src/pages/luckyBoard/luckyBoardAfter/LuckyBoardAfterPage.styled.ts
+++ b/src/pages/luckyBoard/luckyBoardAfter/LuckyBoardAfterPage.styled.ts
@@ -6,25 +6,29 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  height: 80vh;
 `;
 
 export const TextBox = styled.div`
   ${({ theme }) => css`
     color: ${theme.colors.black};
     ${theme.fonts.headline1};
-    margin: 20px 0px 5px 0px;
+    margin: 20px 0px 20px 0px;
     text-align: center;
     white-space: pre-wrap;
   `}
 `;
 
 export const LuckyMachine = styled.div`
-  width: 430px;
-  height: 630px;
+  aspect-ratio: 430 / 625;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-size: cover;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
   background-image: url("/images/machine-filled.webp");
 `;
 

--- a/src/pages/luckyBoard/luckyBoardBefore/LuckyBoardBeforePage.styled.ts
+++ b/src/pages/luckyBoard/luckyBoardBefore/LuckyBoardBeforePage.styled.ts
@@ -6,6 +6,8 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  height: 80vh;
 `;
 
 export const TextBox = styled.div`
@@ -19,11 +21,14 @@ export const TextBox = styled.div`
 `;
 
 export const LuckyMachine = styled.div`
-  width: 430px;
-  height: 625px;
+  aspect-ratio: 430 / 625;
+  max-width: 430px;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-size: cover;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
   background-image: url("/images/machine-empty.webp");
 `;

--- a/src/pages/luckyDayCycleList/LuckyDayCycleListPage.styled.ts
+++ b/src/pages/luckyDayCycleList/LuckyDayCycleListPage.styled.ts
@@ -32,6 +32,7 @@ export const MenuBox = styled.div`
     color: ${theme.colors.black};
     ${theme.fonts.headline1}
     border-bottom: 1px solid ${theme.colors.gray};
+    transition: color 0.2s ease;
     &:hover {
       color: ${theme.colors.orange};
     }

--- a/src/pages/myPage/myPage.styled.ts
+++ b/src/pages/myPage/myPage.styled.ts
@@ -32,6 +32,7 @@ export const MenuBox = styled.div`
     color: ${theme.colors.black};
     ${theme.fonts.headline1}
     border-bottom: 1px solid ${theme.colors.gray};
+    transition: color 0.2s ease;
     &:hover {
       color: ${theme.colors.orange};
     }

--- a/src/styles/themes/colors.ts
+++ b/src/styles/themes/colors.ts
@@ -9,6 +9,7 @@ export const colors = {
   purple: "#BD7DFF",
   lightPurple: "#EEDFF5",
   white: "#ffffff",
+  background: "#faf7f3",
 } as const;
 
 export type Colors = typeof colors;


### PR DESCRIPTION
## ISSUE 번호

#117

<br/>

## 🔎 작업 내용

- Layout 반응형 처리
- NavigationToggle 반응형 처리
- 럭키보드 페이지 (before/after) 반응형 처리
- 아카이브 모달 코드 원복 및 재수정
- background-color 추가

<br/>

## 참고 사항

- Layout의 절대좌표 설정을 제거하였습니다. 변경 후 NavigationToggle의 위치가 화면 기준으로 변경되어 반응형 처리를 추가했습니다. 
- 모바일에서 보니 background-image를 벗어나면 눈에 확 띄는 것 같아서 가장 유사한 컬러로 background-color를 설정했습니다. 
- 배포 버전에서 보니 아카이브 모달 중 "더보기"에서 UI가 깨지는 것을 발견했습니다. 현진님 코드로 원복한 상태이며, 해당 코드에서 컬러만 변경했습니다. 
- 럭키보드 페이지 반응형 처리를 UI가 깨져보이는 너비 기준으로 작업하였습니다. 