### PR TITLE
Feat/#203 럭키데이 보관함 사이클 리스트 review check 필드 추가

### DIFF
--- a/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.styled.ts
+++ b/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.styled.ts
@@ -1,0 +1,15 @@
+import { css, Theme } from "@emotion/react";
+
+export const modal = (theme: Theme) =>
+  css`
+    div {
+      align-items: center;
+      justify-content: center;
+      p {
+        width: 100%;
+      }
+      strong {
+        color: ${theme.colors.orange};
+      }
+    }
+  `;

--- a/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.tsx
+++ b/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.tsx
@@ -37,6 +37,6 @@ export default function SendFeedbackMessage({
       baseLabel="바로가기"
       handleCancelClick={handleCancelClick}
       handleBaseClick={handleConfirmClick}
-    ></ConfirmModal>
+    />
   );
 }

--- a/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.tsx
+++ b/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.tsx
@@ -11,7 +11,8 @@ export default function SendFeedbackMessage({
   const surveyFormUrl = import.meta.env.VITE_SURVEY_FORM;
 
   const handleConfirmClick = () => {
-    window.location.href = surveyFormUrl;
+    window.open(surveyFormUrl, "_blank", "noopener,noreferrer");
+    onClose();
   };
 
   const handleCancelClick = () => {

--- a/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.tsx
+++ b/src/components/common/layout/navigationToggle/sendFeedbackMessage/SendFeedbackMessage.tsx
@@ -1,0 +1,41 @@
+import * as S from "./SendFeedbackMessage.styled";
+import { ConfirmModal } from "components/common";
+
+interface SendFeedbackMessageProps {
+  onClose: () => void;
+}
+
+export default function SendFeedbackMessage({
+  onClose,
+}: SendFeedbackMessageProps) {
+  const surveyFormUrl = import.meta.env.VITE_SURVEY_FORM;
+
+  const handleConfirmClick = () => {
+    window.location.href = surveyFormUrl;
+  };
+
+  const handleCancelClick = () => {
+    onClose();
+  };
+
+  const subTitle = (
+    <p>
+      <strong>[게시판]- [만족도 설문 보내기]</strong>에서 <br /> 더 자세하고 긴
+      피드백을 <br /> 작성하실 수 있어요! <br /> <br /> 매월 기프티콘 추첨도
+      있으니 <br />
+      많은 참여 부탁드려요!
+    </p>
+  );
+
+  return (
+    <ConfirmModal
+      css={S.modal}
+      title="피드백이 전달되고 있어요!"
+      subTitle={subTitle}
+      cancelLabel="취소"
+      baseLabel="바로가기"
+      handleCancelClick={handleCancelClick}
+      handleBaseClick={handleConfirmClick}
+    ></ConfirmModal>
+  );
+}

--- a/src/components/common/layout/navigationToggle/sendFeedbackMessage/index.ts
+++ b/src/components/common/layout/navigationToggle/sendFeedbackMessage/index.ts
@@ -1,0 +1,1 @@
+export { default as SendFeedbackMessage } from "./SendFeedbackMessage";

--- a/src/components/common/layout/navigationToggle/sendFeedbackModal/SendFeedbackModal.tsx
+++ b/src/components/common/layout/navigationToggle/sendFeedbackModal/SendFeedbackModal.tsx
@@ -1,4 +1,5 @@
 import * as S from "./SendFeedbackModal.styled";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTheme } from "@emotion/react";
 import { useToast } from "hooks";
@@ -6,6 +7,7 @@ import { useSendFeedback } from "services";
 import { FeedbackFormValues } from "types";
 import { BaseModal, SvgButton, PageSpinner } from "components";
 import { ShortBoxIcon } from "assets";
+import { SendFeedbackMessage } from "../sendFeedbackMessage";
 
 interface SendFeedbackModalProps {
   onClose: () => void;
@@ -14,6 +16,7 @@ interface SendFeedbackModalProps {
 export default function SendFeedbackModal({ onClose }: SendFeedbackModalProps) {
   const theme = useTheme();
   const { addToast } = useToast();
+  const [feedbackSent, setFeedbackSent] = useState(false);
 
   const {
     register,
@@ -49,7 +52,7 @@ export default function SendFeedbackModal({ onClose }: SendFeedbackModalProps) {
       {
         onSuccess: () => {
           addToast({ content: "피드백이 전송되었습니다." });
-          onClose();
+          setFeedbackSent(true);
         },
         onError: (error) => {
           addToast({ content: "오류가 발생했습니다. 다시 시도해 주세요." });
@@ -61,6 +64,10 @@ export default function SendFeedbackModal({ onClose }: SendFeedbackModalProps) {
 
   const isButtonDisabled =
     feedbackValue.length === 0 || feedbackValue.length > 160;
+
+  if (feedbackSent) {
+    return <SendFeedbackMessage onClose={onClose} />;
+  }
 
   return (
     <BaseModal>

--- a/src/components/common/modal/confirmModal/ConfirmModal.styled.ts
+++ b/src/components/common/modal/confirmModal/ConfirmModal.styled.ts
@@ -96,7 +96,7 @@ export const BaseButton = styled.button`
 
 export const SubTitle = styled.div`
   ${({ theme }) => css`
-    ${theme.fonts.body2};
+    ${theme.fonts.body1};
     position: absolute;
     display: flex;
     width: 100%;

--- a/src/components/domain/myPage/resetLuckyBoardModal/ResetLuckyBoardModal.styled.ts
+++ b/src/components/domain/myPage/resetLuckyBoardModal/ResetLuckyBoardModal.styled.ts
@@ -1,19 +1,13 @@
 import { css, Theme } from "@emotion/react";
-import styled from "@emotion/styled";
 
 export const modal = (theme: Theme) =>
   css`
     div {
-      ${theme.fonts.body1};
+      align-items: center;
+      justify-content: center;
       p {
         width: 100%;
+        color: ${theme.colors.black};
       }
     }
   `;
-
-export const TextBox = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-`;

--- a/src/components/domain/myPage/resetLuckyBoardModal/ResetLuckyBoardModal.tsx
+++ b/src/components/domain/myPage/resetLuckyBoardModal/ResetLuckyBoardModal.tsx
@@ -1,19 +1,14 @@
 import * as S from "./ResetLuckyBoardModal.styled";
-import { useTheme } from "@emotion/react";
-import { ConfirmModal, SvgButton } from "components";
-import { LargeBoxIcon } from "assets";
+import { ConfirmModal } from "components";
 import { useModal } from "hooks";
 
 interface ResetLuckyBoardModalProps {
-  label?: string;
   onReset: () => void;
 }
 
 export default function ResetLuckyBoardModal({
-  label = "럭키 보드에 생성되어 있는 \n 모든 럭키 데이가 삭제되고, \n 럭키 보드가 초기화됩니다. \n 삭제된 정보는 복구할 수 없습니다.",
   onReset,
 }: ResetLuckyBoardModalProps) {
-  const theme = useTheme();
   const { handleModalClose } = useModal();
 
   const handleCancelClick = () => {
@@ -25,25 +20,24 @@ export default function ResetLuckyBoardModal({
     handleModalClose();
   };
 
+  const subTitle = (
+    <p>
+      럭키 보드에 생성되어 있는 <br />
+      모든 럭키 데이가 삭제되고, <br />
+      럭키 보드가 초기화됩니다. <br />
+      삭제된 정보는 복구할 수 없습니다.
+    </p>
+  );
+
   return (
-    <>
-      <ConfirmModal
-        css={S.modal}
-        title="럭키보드를 초기화하시겠어요?"
-        cancelLabel="취소"
-        baseLabel="초기화"
-        handleCancelClick={handleCancelClick}
-        handleBaseClick={handleResetlick}
-      >
-        <SvgButton
-          label={label}
-          icon={<LargeBoxIcon />}
-          textColor={theme.colors.black}
-          fillColor={theme.colors.lightPurple}
-          width="240px"
-          height="200px"
-        ></SvgButton>
-      </ConfirmModal>
-    </>
+    <ConfirmModal
+      css={S.modal}
+      title="럭키보드를 초기화하시겠어요?"
+      subTitle={subTitle}
+      cancelLabel="취소"
+      baseLabel="초기화"
+      handleCancelClick={handleCancelClick}
+      handleBaseClick={handleResetlick}
+    ></ConfirmModal>
   );
 }

--- a/src/components/domain/myPage/resetLuckyBoardModal/ResetLuckyBoardModal.tsx
+++ b/src/components/domain/myPage/resetLuckyBoardModal/ResetLuckyBoardModal.tsx
@@ -38,6 +38,6 @@ export default function ResetLuckyBoardModal({
       baseLabel="초기화"
       handleCancelClick={handleCancelClick}
       handleBaseClick={handleResetlick}
-    ></ConfirmModal>
+    />
   );
 }

--- a/src/pages/luckyDayCycleDetail/LuckyDayCycleDetailPage.tsx
+++ b/src/pages/luckyDayCycleDetail/LuckyDayCycleDetailPage.tsx
@@ -6,7 +6,7 @@ import { CircleBoxIcon } from "assets";
 import { GetLuckyDayCycleDetail } from "types";
 import { useGetLuckyDayCycleDetails } from "services";
 
-const LuckyDayCycleDetailPage = () => {
+export default function LuckyDayCycleDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { data, isLoading, error } = useGetLuckyDayCycleDetails(Number(id));
   const theme = useTheme();
@@ -29,6 +29,7 @@ const LuckyDayCycleDetailPage = () => {
     data?.resData?.map((item: GetLuckyDayCycleDetail) => ({
       date: item.date,
       dtlNo: item.dtlNo,
+      reviewCheck: item.reviewCheck,
     })) || [];
 
   return (
@@ -44,7 +45,11 @@ const LuckyDayCycleDetailPage = () => {
               width="80px"
               height="80px"
               textColor={theme.colors.white}
-              fillColor={theme.colors.purple}
+              fillColor={
+                label.reviewCheck === 1
+                  ? theme.colors.lightOrange
+                  : theme.colors.purple
+              }
               onClick={() => navigate(`/luckydays/${label.dtlNo}`)}
             />
           ))}
@@ -52,6 +57,4 @@ const LuckyDayCycleDetailPage = () => {
       </S.ContentsBox>
     </SingleButtonLayout>
   );
-};
-
-export default LuckyDayCycleDetailPage;
+}

--- a/src/pages/noticeBoard/NoticeBoardPage.tsx
+++ b/src/pages/noticeBoard/NoticeBoardPage.tsx
@@ -9,9 +9,9 @@ export default function NoticeBoardPage() {
     <SingleButtonLayout>
       <S.TitleBox>게시판</S.TitleBox>
       <S.ContentsBox>
-        <Link to={surveyFormUrl}>
+        <a href={surveyFormUrl} target="_blank" rel="noopener noreferrer">
           <S.MenuBox>만족도 설문 보내기</S.MenuBox>
-        </Link>
+        </a>
         <Link to="/noticeboard/info">
           <S.MenuBox>만든 사람들</S.MenuBox>
         </Link>

--- a/src/pages/reviewLuckyDay/ReviewLuckyDayPage.styled.ts
+++ b/src/pages/reviewLuckyDay/ReviewLuckyDayPage.styled.ts
@@ -133,3 +133,20 @@ export const ErrorText = styled.p`
     ${theme.fonts.body2}
   `}
 `;
+
+export const ImageDeleteButton = styled.div`
+  ${({ theme }) => css`
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    bottom: 0;
+    right: 0;
+    width: 30px;
+    height: 30px;
+    margin: 8px;
+    border-radius: 50%;
+    background-color: ${theme.colors.beige};
+    cursor: pointer;
+  `}
+`;

--- a/src/types/domain/luckyday.ts
+++ b/src/types/domain/luckyday.ts
@@ -85,6 +85,7 @@ export interface GetLuckyDayCycleDetail {
   dday: number;
   order: number;
   date: string;
+  reviewCheck: number;
 }
 
 export interface GetLuckyDayCycleLastLuckyDaysQueryModel {


### PR DESCRIPTION
## ISSUE 번호

- #203 

<br/>

## 🔎 작업 내용 요약

- 럭키데이 사이클 `reviewCheck` 필드 추가
- `SendFeedbackMessage` 컴포넌트 생성, 피드백 보내기 성공 이후 연결
- `ResetLuckyBoardModal` refactor
- 설문폼 이동 시 새 탭에서 열도록 로직 수정

<br/>

## 상세 내용

- 럭키데이 보관함 - 더보기에서 리뷰가 있는 럭키데이는 lightOrange로 렌더링 되도록 변경했습니다.

<img width="986" alt="스크린샷 2024-09-29 오후 10 27 45" src="https://github.com/user-attachments/assets/3b3a5cfa-5b9c-40b9-b4a8-06dc96d639c0">

- 이전에 피드백 보내기 동작 시 api 응답까지 시간이 걸려서 스피너를 추가해두었는데, 스피너 대신 설문폼에 대한 언급을 추가하는 것이 어떠냐는 의견이 있었습니다. 이 아이디어를 저번 회의에서 논의한대로 [기존 스피너 유지 - 성공 시 완료 메시지에 설문폼 안내]로 변경하였습니다.


https://github.com/user-attachments/assets/bcd13141-60a0-4955-90eb-f8afce717825


- 설문폼 링크 연결 시 새 탭에서 열리도록 수정하였습니다. 

</br>
