### PR TITLE
Feat/#224 버튼레이아웃 및 럭키데이생성 css 수정

### DIFF
--- a/src/components/common/layout/buttonLayout/ButtonLayout.styled.ts
+++ b/src/components/common/layout/buttonLayout/ButtonLayout.styled.ts
@@ -25,11 +25,9 @@ export const icon = css`
   height: 24px;
 `;
 
-export const Button = styled.button<{ variant?: "hasIcon" | "hasColor" }>`
-  ${({ variant }) => css`
-    position: relative;
-    width: ${variant === "hasColor" ? "120px" : "100px"};
-  `}
+export const Button = styled.button`
+  position: relative;
+  width: 90px;
 `;
 
 export const ButtonBox = styled.div<{
@@ -39,11 +37,11 @@ export const ButtonBox = styled.div<{
   ${({ theme, isSecond, variant }) => css`
     ${theme.fonts.headline2};
     position: absolute;
-    top: ${variant === "hasColor" && !isSecond ? "12px" : "9px"};
+    top: ${variant === "hasColor" && !isSecond ? "10px" : "8px"};
     left: ${variant === "hasColor"
       ? isSecond
         ? "28px"
-        : "13px"
+        : "10px"
       : isSecond
       ? "21px"
       : "10px"};

--- a/src/components/common/layout/buttonLayout/ButtonLayout.tsx
+++ b/src/components/common/layout/buttonLayout/ButtonLayout.tsx
@@ -32,7 +32,7 @@ function ButtonLayout({
       <S.Body>{children}</S.Body>
       {!isHideButtons && (
         <S.ButtonWrapper>
-          <S.Button variant={variant} onClick={handleClickFirstButton}>
+          <S.Button onClick={handleClickFirstButton}>
             <SvgFrame css={S.beigeIcon} icon={<ShortBoxIcon />} />
             <S.ButtonBox variant={variant}>
               {icon && icon}

--- a/src/components/domain/createLuckyDay/container/calendar/Calendar.styled.ts
+++ b/src/components/domain/createLuckyDay/container/calendar/Calendar.styled.ts
@@ -118,6 +118,7 @@ export const DayButton = styled.button<{
   isChecked: boolean;
 }>`
   ${({ isSelected, isExceptDate, isChecked, theme }) => css`
+    ${theme.fonts.body1};
     height: 35px;
     border-radius: 50%;
     border: 0;

--- a/src/components/domain/createLuckyDay/selectActivity/SelectActivity.styled.ts
+++ b/src/components/domain/createLuckyDay/selectActivity/SelectActivity.styled.ts
@@ -29,6 +29,8 @@ export const icon = css`
 
 export const Button = styled.button<{ isNotChecked: boolean }>`
   ${({ theme, isNotChecked }) => css`
+    display: flex;
+    align-items: center;
     border-radius: 30px;
     padding: 0 11px;
     background-color: ${isNotChecked
@@ -36,12 +38,18 @@ export const Button = styled.button<{ isNotChecked: boolean }>`
       : theme.colors.gray};
 
     & > span {
-      ${theme.fonts.headline3};
+      ${theme.fonts.body1};
+      margin-top: 2px;
       color: ${!isNotChecked && theme.colors.white};
     }
 
-    & > svg > path {
-      fill: ${!isNotChecked && theme.colors.white};
+    & > svg {
+      width: 20px;
+      height: 20px;
+
+      & > path {
+        fill: ${!isNotChecked && theme.colors.white};
+      }
     }
   `}
 `;

--- a/src/components/domain/createLuckyDay/selectActivity/container/activityToggle/ActivityToggle.styled.ts
+++ b/src/components/domain/createLuckyDay/selectActivity/container/activityToggle/ActivityToggle.styled.ts
@@ -62,6 +62,7 @@ export const ActivityInfo = styled.div<{ isOpen: boolean; isChecked: boolean }>`
 export const ActivityTitle = styled.span`
   ${({ theme }) => css`
     ${theme.fonts.headline1};
+    margin-top: 4%;
 
     @media (max-width: 380px) {
       ${theme.fonts.headline1};
@@ -92,7 +93,7 @@ export const Activities = styled.div`
 
 export const Activity = styled.button<{ isSelected?: boolean }>`
   ${({ theme, isSelected }) => css`
-    ${theme.fonts.headline3};
+    ${theme.fonts.body1};
     display: flex;
     align-items: center;
     column-gap: 3px;
@@ -129,11 +130,11 @@ export const icon = css`
 
 export const input = (width?: number) => (theme: Theme) =>
   css`
+    ${theme.fonts.body1};
     width: ${width ? `calc(${width}px * 1.2 + 16px)` : "22px"};
     padding: 0;
     border: 0;
     background-color: ${theme.colors.lightBeige};
-    font-size: 1.6rem;
     outline: none;
   `;
 
@@ -143,7 +144,8 @@ export const customActiviyItem = styled.span`
 `;
 
 export const CustomInfo = styled.div<{ isCustom?: boolean }>`
-  ${({ isCustom }) => css`
+  ${({ theme, isCustom }) => css`
+    ${theme.fonts.body1};
     position: absolute;
     bottom: 60px;
     left: 0;
@@ -154,7 +156,6 @@ export const CustomInfo = styled.div<{ isCustom?: boolean }>`
 
 export const ContentLength = styled.span`
   ${({ theme }) => css`
-    ${theme.fonts.headline3};
     position: absolute;
     left: 40px;
     color: ${theme.colors.black};
@@ -163,6 +164,7 @@ export const ContentLength = styled.span`
 
 export const AddButton = styled.button`
   ${({ theme }) => css`
+    ${theme.fonts.body1};
     position: absolute;
     right: 40px;
     width: 60px;

--- a/src/components/domain/createLuckyDay/selectCount/SelectCount.styled.ts
+++ b/src/components/domain/createLuckyDay/selectCount/SelectCount.styled.ts
@@ -42,6 +42,7 @@ export const SelectDatesBox = styled.div`
     justify-content: center;
     width: 100px;
     height: 40px;
+    padding-top: 2%;
     border-radius: 20px;
     background-color: ${theme.colors.beige};
   `}

--- a/src/components/domain/createLuckyDay/selectPeriod/SelectPeriod.styled.ts
+++ b/src/components/domain/createLuckyDay/selectPeriod/SelectPeriod.styled.ts
@@ -20,12 +20,13 @@ export const SubHeadLine = styled.span`
 export const PeriodWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  row-gap: 14px; //TODO: 피그마와 간격이 상이함 확인 필요-> 피그마 간격대로 적용 시 간격이 동일하지 않음
+  align-items: center;
+  row-gap: 30px;
 `;
 
 export const ActivityButton = styled.button`
   position: relative;
-  width: 100%;
+  width: 315px;
 `;
 
 export const icon = (isSelected: boolean) => (theme: Theme) =>
@@ -46,7 +47,7 @@ export const ActivityInfo = styled.div`
   align-items: center;
   width: 100%;
   height: 100%;
-  padding: 15px 20px 15px 30px;
+  margin-top: 2%;
 `;
 
 export const ActivityTitle = styled.span`
@@ -64,7 +65,7 @@ export const arrowIcon = css`
 export const SelectInfo = styled.p`
   ${({ theme }) => css`
     ${theme.fonts.body1}
-    margin-top: 42px;
+    margin-top: 50px;
     text-align: center;
 
     & > strong {


### PR DESCRIPTION
## ISSUE 번호

- #224

<br/>

## 🔎 작업 내용

- 버튼 레이아웃 css 수정
- 럭키데이 생성 플로우 > css 수정

<br/>

## 참고 사항

- 확인해보니, 럭키데이 활동 선택 시 선택창이 열린 상태의 사각형 png가 google drive에 안올라와있어서 해당 부분까지는 적용 못했습니다. 화요일에 요청드린 후 적용 예정이니 참고부탁드립니다.
