### PR TITLE
Feat/#239 권한 없는 접근 에러처리 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Global, ThemeProvider } from "@emotion/react";
 import { RecoilRoot } from "recoil";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useTokenExpiration } from "hooks";
+import { useAccessDenied, useTokenExpiration } from "hooks";
 
 import { TutorialProvider, TutorialLayout, Modal, Toast } from "components";
 import { globalStyle, theme } from "styles";
@@ -22,6 +22,7 @@ dayjs.locale("ko");
 const queryClient = new QueryClient();
 
 export default function App() {
+  useAccessDenied();
   useTokenExpiration();
 
   return (

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -31,6 +31,14 @@ instance.interceptors.response.use(
       window.dispatchEvent(event);
     }
 
+    if (
+      error.response?.status === 403 ||
+      error.response?.data?.code === "1004"
+    ) {
+      const event = new CustomEvent("ACCESS_DENIED");
+      window.dispatchEvent(event);
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -13,32 +13,28 @@ instance.interceptors.request.use(
     }
     return config;
   },
-  (error) => {
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
 
 instance.interceptors.response.use(
   (response: AxiosResponse) => {
+    if (response.data?.code === "1004") {
+      window.dispatchEvent(new CustomEvent("ACCESS_DENIED"));
+      return Promise.reject();
+    }
+    if (response.data?.code === "1001") {
+      window.dispatchEvent(new CustomEvent("TOKEN_EXPIRED"));
+      return Promise.reject();
+    }
     return response;
   },
   (error) => {
-    if (
-      error.response?.status === 401 ||
-      error.response?.data?.code === "1001"
-    ) {
-      const event = new CustomEvent("TOKEN_EXPIRED");
-      window.dispatchEvent(event);
+    if (error.response?.status === 403) {
+      window.dispatchEvent(new CustomEvent("ACCESS_DENIED"));
     }
-
-    if (
-      error.response?.status === 403 ||
-      error.response?.data?.code === "1004"
-    ) {
-      const event = new CustomEvent("ACCESS_DENIED");
-      window.dispatchEvent(event);
+    if (error.response?.status === 401) {
+      window.dispatchEvent(new CustomEvent("TOKEN_EXPIRED"));
     }
-
     return Promise.reject(error);
   }
 );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useModal } from "./useModal";
 export { default as useToast } from "./useToast";
+export { default as useAccessDenied } from "./useAccessDenied";
 export { default as useTokenExpiration } from "./useTokenExpiration";

--- a/src/hooks/useAccessDenied.ts
+++ b/src/hooks/useAccessDenied.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useToast } from "hooks";
+
+export default function useAccessDenied() {
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    const handleAccessDenied = () => {
+      addToast({
+        content: "접근 권한이 없습니다.",
+      });
+      setTimeout(() => {
+        window.history.back();
+      }, 1000);
+    };
+
+    window.addEventListener("ACCESS_DENIED", handleAccessDenied);
+    return () => {
+      window.removeEventListener("ACCESS_DENIED", handleAccessDenied);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {};
+}

--- a/src/pages/noticeList/NoticeListPage.tsx
+++ b/src/pages/noticeList/NoticeListPage.tsx
@@ -24,11 +24,15 @@ export default function NoticeListPage() {
     navigate(`/notice/${id}`);
   };
 
+  const sortedNotices = [...NOTICE_DETAILS].sort((a, b) => {
+    return Number(b.id) - Number(a.id);
+  });
+
   return (
     <SingleButtonLayout>
       <S.TitleBox>공지사항</S.TitleBox>
       <S.ContentsBox>
-        {NOTICE_DETAILS.map((notice) => (
+        {sortedNotices.map((notice) => (
           <NoticeMenu
             key={notice.id}
             id={notice.id}


### PR DESCRIPTION
## ISSUE 번호

- #239 

<br/>

## 🔎 작업 내용

- useAccessDenied hook 생성 -> 권한 없음 처리 로직 추가
- HTTP 상태 코드(401, 403)와 API 응답 코드(1001, 1004) 모두 처리되도록 수정
- success 응답의 에러 코드도 처리되도록 로직 분리
- 공지사항 리스트 최신순으로 정렬 로직 추가

<br/>

## 참고 사항

- 아직 백엔드 api가 수정되지 않았는데, 프론트 코드는 크게 달라질 내용이 없을 것 같아 미리 작업했습니다. 
- 공지사항 상수를 분리하면서 리스트 순서가 id 순으로 정렬되고 있어 최신순으로 정렬되도록 수정했습니다.
