### PR TITLE
Feat/#250 아카이브 모달 review check 필드 추가 및 관심사 분리

### DIFF
--- a/src/components/domain/luckyBoard/archiveModal/ArchiveModal.styled.ts
+++ b/src/components/domain/luckyBoard/archiveModal/ArchiveModal.styled.ts
@@ -59,7 +59,7 @@ export const ButtonWrapper = styled.div`
   }
 `;
 
-export const Button = styled.button`
+export const BottomButton = styled.button`
   ${({ theme }) => css`
     flex: 0 0 auto;
     position: relative;
@@ -84,40 +84,27 @@ export const LuckyDayButtonWrapper = styled.div`
   grid-template-columns: repeat(4, 1fr);
   gap: 21px 20px;
   width: 100%;
+
+  @media (max-width: 405px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
 `;
 
-export const LuckyDayButton = styled.button`
-  ${({ theme }) => css`
-    position: relative;
-    width: 75px;
-    height: 75px;
-    margin: 8px 4px;
+export const LuckyDayButton = styled.div`
+  position: relative;
+  width: 75px;
+  height: 75px;
+  margin: 8px 4px;
 
-    @media (max-width: 412px) {
-      width: 72px;
-      height: 72px;
-    }
+  @media (max-width: 412px) {
+    width: 72px;
+    height: 72px;
+  }
 
-    @media (max-width: 405px) {
-      width: 68px;
-      height: 68px;
-    }
-
-    & > div {
-      width: 100%;
-      height: 100%;
-    }
-
-    & > span {
-      position: absolute;
-      width: 100%;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      ${theme.fonts.headline2};
-      color: ${theme.colors.white};
-    }
-  `}
+  @media (max-width: 405px) {
+    width: 68px;
+    height: 68px;
+  }
 `;
 
 export const BasicSvgFrame = (theme: Theme) => css`

--- a/src/components/domain/luckyBoard/archiveModal/ArchiveModal.tsx
+++ b/src/components/domain/luckyBoard/archiveModal/ArchiveModal.tsx
@@ -1,12 +1,13 @@
 import * as S from "./ArchiveModal.styled";
 import { useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useTheme } from "@emotion/react";
 import { useModal, useToast } from "hooks";
 import { useVisibility } from "./hooks";
 import { useDeleteLuckyBoard } from "services";
-import type { GetLuckyDayCycleDetail } from "types";
-import { ResetLuckyBoardModal, SvgFrame } from "components";
+import { ResetLuckyBoardModal, SvgButton, SvgFrame } from "components";
 import { CircleBoxIcon, ShortBoxIcon } from "assets";
+import type { GetLuckyDayCycleDetail } from "types";
 
 interface ArchiveModalProps {
   className?: string;
@@ -27,6 +28,7 @@ export default function ArchiveModal({
   const { handleOpenModal, handleModalClose } = useModal();
   const { addToast } = useToast();
 
+  const theme = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -78,13 +80,21 @@ export default function ArchiveModal({
         <>
           {lastInfo?.length ? (
             <S.LuckyDayButtonWrapper>
-              {lastInfo?.map((item) => (
-                <S.LuckyDayButton
-                  key={item.dtlNo}
-                  onClick={moveToDetail(item.dtlNo)}
-                >
-                  <SvgFrame css={S.PurpleSvgFrame} icon={<CircleBoxIcon />} />
-                  <span>{item.date}</span>
+              {lastInfo.map((item) => (
+                <S.LuckyDayButton key={item.dtlNo}>
+                  <SvgButton
+                    label={item.date}
+                    icon={<CircleBoxIcon />}
+                    width="100%"
+                    height="100%"
+                    textColor={theme.colors.white}
+                    fillColor={
+                      item.reviewCheck === 1
+                        ? theme.colors.lightOrange
+                        : theme.colors.purple
+                    }
+                    onClick={moveToDetail(item.dtlNo)}
+                  />
                 </S.LuckyDayButton>
               ))}
             </S.LuckyDayButtonWrapper>
@@ -99,18 +109,18 @@ export default function ArchiveModal({
 
       <S.ButtonWrapper>
         {isMoreInfoModal && (
-          <S.Button onClick={openResetLuckyBoardrModal}>
+          <S.BottomButton onClick={openResetLuckyBoardrModal}>
             <SvgFrame css={S.BasicSvgFrame} icon={<ShortBoxIcon />} />
             <span>럭키보드 초기화</span>
-          </S.Button>
+          </S.BottomButton>
         )}
-        <S.Button onClick={closeModal}>
+        <S.BottomButton onClick={closeModal}>
           <SvgFrame
             css={isMoreInfoModal ? S.PurpleSvgFrame : S.BasicSvgFrame}
             icon={<ShortBoxIcon />}
           />
           <span>닫기</span>
-        </S.Button>
+        </S.BottomButton>
       </S.ButtonWrapper>
     </S.ArchiveModal>
   );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,3 @@
 export * from "./tutorial";
+export * from "./landing";
+export * from "./notice";

--- a/src/pages/luckyBoard/LuckyBoardPage.tsx
+++ b/src/pages/luckyBoard/LuckyBoardPage.tsx
@@ -7,7 +7,6 @@ import {
   useGetLuckyDayCycleInfo,
   useGetLuckyDayCycleLastLuckyDays,
 } from "services";
-import { formatDate } from "utils";
 
 export default function LuckyBoardPage() {
   const hasLuckyday = sessionStorage.getItem("hasLuckyday")!;
@@ -20,57 +19,42 @@ export default function LuckyBoardPage() {
   const { data: lastLuckyDays } = useGetLuckyDayCycleLastLuckyDays({
     query: { isCurrent: 0 },
   });
-  const { data: info } = useGetLuckyDayCycleInfo(data?.[0].cyclNo ?? 0, !!data);
-
-  const { handleOpenModal } = useModal();
-  const { addToast } = useToast();
-
-  const expDatesString = info?.expDtList
-    ?.map((item) => `${formatDate(item, "YYYY-MM-DD")}\n`)
-    .join("")
-    ?.replace(/,/g, "");
-
-  const cycleInfo = (
-    <p>
-      생성 옵션:
-      <br />
-      {info ? formatDate(info.startDt, "YYYY-MM-DD") : "-"} ~{" "}
-      {info ? formatDate(info.endDt, "YYYY-MM-DD") : "-"}
-      <br />
-      <strong>{info?.period}</strong>일 동안 <strong>{info?.cnt}</strong>개의
-      럭키 데이
-      <br />
-      {expDatesString ? `\n제외 날짜:\n${expDatesString}` : ""}
-    </p>
+  const { data: cycleInfo } = useGetLuckyDayCycleInfo(
+    data?.[0].cyclNo ?? 0,
+    !!data
   );
 
+  const { handleOpenModal, handleModalClose } = useModal();
+  const { addToast } = useToast();
+
   const handleOpenLastLuckyDayModal = () => {
-    if (!lastLuckyDays && !data?.[0].cyclNo) {
-      return;
-    }
+    if (!lastLuckyDays && !data?.[0].cyclNo) return;
+
+    const filteredLastInfo =
+      lastLuckyDays?.filter((item) => item.dday !== 1 && item.date !== null) ||
+      [];
 
     handleOpenModal(
       <ArchiveModal
         css={S.archiveModal}
-        lastInfo={
-          lastLuckyDays?.filter(
-            (item) => item.dday !== 1 && item.date !== null
-          ) || []
-        }
+        lastInfo={filteredLastInfo}
         isMoreInfoModal={false}
+        onClose={handleModalClose}
       />
     );
   };
 
   const handleOpenCheckLuckyDayModal = () => {
-    if (!info)
+    if (!cycleInfo) {
       return addToast({ content: "진행 중인 럭키 데이 정보가 없어요." });
+    }
 
     handleOpenModal(
       <ArchiveModal
         css={S.archiveModal}
-        moreInfo={cycleInfo}
+        cycleInfo={cycleInfo}
         isMoreInfoModal={true}
+        onClose={handleModalClose}
       />
     );
   };

--- a/src/pages/luckyDayCycleDetail/LuckyDayCycleDetailPage.styled.ts
+++ b/src/pages/luckyDayCycleDetail/LuckyDayCycleDetailPage.styled.ts
@@ -5,7 +5,7 @@ export const ContentsBox = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: 0px 10px 0px 10px;
+  margin: 0px 10px;
   padding: 20px;
 `;
 

--- a/src/types/domain/luckyday.ts
+++ b/src/types/domain/luckyday.ts
@@ -53,7 +53,7 @@ export interface GetLuckyDayDetailServerModel extends CommonServerModel {
   resData: GetLuckyDayDetail;
 }
 
-interface GetLuckyDayCycleInfo {
+export interface GetLuckyDayCycleInfo {
   startDt: string;
   endDt: string;
   period: number;


### PR DESCRIPTION
## ISSUE 번호

- #250 

<br/>

## 🔎 작업 내용

- ArchiveModal 내 럭키볼에 리뷰 상태 표시 기능 추가 -> reviewCheck 값에 따른 조건부 스타일링 추가
- ArchiveModal props 인터페이스 변경 (원본 데이터로 전달)
- onClose prop 추가 및 handleModalClose 의존성 제거
- LuckyBoardPage 내부에 있던 데이터 포맷팅 로직 ArchiveModal 내부로 이동 (관심사 분리)

<br/>
